### PR TITLE
Added new syntax to repeat a dice roll action

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You can roll multiple dice, add modifiers etc. to your rolls examples below and 
 - `/r 2d20kh1 + 7` Roll keeping the highest result then adding 7
 - `/r 2d20kl1 + 8` Roll keeping the lowest result then adding 8
 - `/r 2d8*2 + 2` Roll 2d8 times the result by 2 and then add 2
+- `/r 3[2d6 + 5]` Repeat the action of rolling 2d6 and then adding 5
 
 #### Calculation
 Basic calculation can be done by using `/c`: adding, subtracting, multiplication, division, and brackets


### PR DESCRIPTION
To roll an action multiple times the syntax is `/r {number of times to repeat}[{dice roll action}]` 
Example: `/r 3[2d20kh1 + 5]` Repeating 3 times the following; rolling 2d20 keeping highest result then adding 5. This gives 3 results shown separately in square brackets.

example output: "@user `3[2d20kh1+5]` = [(~~3~~, 10) + 5][(~~11~~, 16) + 5][(9, ~~1~~) + 5] = [15] [21] [14]"