### PR TITLE
Added cache to async_get using async-cache package

### DIFF
--- a/requests_handler/async_requests.py
+++ b/requests_handler/async_requests.py
@@ -1,7 +1,9 @@
 import httpx
+from cache import AsyncTTL
 from httpx import Timeout
 
 
+@AsyncTTL(time_to_live=86400, min_cleanup_interval=3600)
 async def async_get(url: str, return_json: bool = True):
     async with httpx.AsyncClient(timeout=Timeout(timeout=10.0)) as client:
         raw_response = await client.get(url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py
 httpx
+async-cache


### PR DESCRIPTION
Using AsyncTTL from the async-cache package all async_get calls will cache results for 24 hours before deleting the result from the cache